### PR TITLE
Check if not a left-click, then bail out of onStart

### DIFF
--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -80,6 +80,14 @@ dragElement.init = function init(options) {
     function onStart(e) {
         // make dragging and dragged into properties of gd
         // so that others can look at and modify them
+
+        var rightclick;
+        if(e.which) { rightclick = (e.which === 3); }
+        else if(e.button) { rightclick = (e.button === 2); }
+        if(rightclick) {
+            return;
+        }
+
         gd._dragged = false;
         gd._dragging = true;
         var offset = pointerOffset(e);


### PR DESCRIPTION
Related to [#248](https://github.com/plotly/plotly.js/issues/248)

This PR adds check in dragElement. On start, if not a left-click,  then bail out of onStart. The purpose of this check is to let developers to use their own context menu instead of browser context menu. Without that check there were no possibility to see 'contextmenu' event when click inside plot container.